### PR TITLE
feat(phase-2): 执行管线框架 + LLM 唯一入口 + MaintenanceReport

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -2,7 +2,9 @@
   "kb_name": {
     "description": "记忆知识库",
     "type": "list",
-    "items": {"type": "string"},
+    "items": {
+      "type": "string"
+    },
     "default": [],
     "_special": "select_knowledgebase",
     "hint": "选择用于存储长期记忆的知识库（必填，请先在知识库管理中创建，知识库需配置嵌入模型）"
@@ -32,7 +34,11 @@
     "type": "int",
     "default": 20,
     "hint": "每N轮对话后触发一次记忆提取，对这N轮对话内容进行总结",
-    "slider": {"min": 5, "max": 200, "step": 1}
+    "slider": {
+      "min": 5,
+      "max": 200,
+      "step": 1
+    }
   },
   "extraction_min_content_length": {
     "description": "最小提取内容长度",
@@ -57,14 +63,22 @@
     "type": "int",
     "default": 200,
     "hint": "限制 /memory list 为计算当前用户可见记忆而扫描的最大记录数。实际扫描量会按当前页码和每页数量推导，并不会超过此上限",
-    "slider": {"min": 20, "max": 2000, "step": 20}
+    "slider": {
+      "min": 20,
+      "max": 2000,
+      "step": 20
+    }
   },
   "memory_delete_scan_page_size": {
     "description": "记忆删除扫描分页大小",
     "type": "int",
     "default": 1000,
     "hint": "删除或清空记忆前，每页扫描多少条匹配记录用于同步清理知识库文档记录。数值越大速度越快但单次内存占用更高",
-    "slider": {"min": 100, "max": 5000, "step": 100}
+    "slider": {
+      "min": 100,
+      "max": 5000,
+      "step": 100
+    }
   },
   "memory_ttl_days": {
     "description": "记忆生命周期(天)",
@@ -89,7 +103,11 @@
     "type": "int",
     "default": 10,
     "hint": "限制检索优化模型调用的最长等待时间。超时后将跳过优化并使用原始检索内容，避免阻塞对话响应",
-    "slider": {"min": 1, "max": 20, "step": 1}
+    "slider": {
+      "min": 1,
+      "max": 20,
+      "step": 1
+    }
   },
   "enable_admin_global_memory_tool": {
     "description": "启用管理员全局记忆工具",
@@ -170,6 +188,18 @@
     "default": "02:00-06:00",
     "hint": "单时间点如 03:00，或范围如 02:00-06:00（范围内空闲时执行）"
   },
+  "maintenance_cron": {
+    "description": "整理周期定时表达式",
+    "type": "string",
+    "default": "0 3 * * *",
+    "hint": "标准 cron 表达式，默认每天 03:00 执行完整整理管线（purge + 整理师 + 分析师 + 审核员）"
+  },
+  "maintenance_max_llm_calls": {
+    "description": "每周期 LLM 调用上限",
+    "type": "int",
+    "default": 50,
+    "hint": "单个整理周期内所有 Agent 的 LLM 调用次数硬上限"
+  },
   "auto_purge_enabled": {
     "description": "自动清理废弃记忆",
     "type": "bool",
@@ -191,7 +221,9 @@
   "maintenance_tasks": {
     "description": "整理团队编排",
     "type": "list",
-    "items": {"type": "object"},
+    "items": {
+      "type": "object"
+    },
     "default": [],
     "hint": "添加后台整理角色（organizer/analyst/reviewer），配置执行时间和行为"
   },
@@ -217,7 +249,11 @@
     "description": "人格加载模式",
     "type": "string",
     "default": "auto",
-    "options": ["auto", "manual", "off"],
+    "options": [
+      "auto",
+      "manual",
+      "off"
+    ],
     "hint": "auto=自动从主人格提取摘要, manual=使用下方自定义, off=不加载"
   },
   "persona_summary": {

--- a/maintenance/__init__.py
+++ b/maintenance/__init__.py
@@ -2,3 +2,19 @@
 
 包含记忆关联管理、物理清理和后台 Agent 调度。
 """
+
+from .links import MemoryLinkManager
+from .llm import MaintenanceLLM, LLMVerdict
+from .purge import purge_deprecated_memories
+from .runner import MaintenanceRunner, MaintenanceReport
+from .scheduler import MaintenanceScheduler
+
+__all__ = [
+    "MemoryLinkManager",
+    "MaintenanceLLM",
+    "LLMVerdict",
+    "MaintenanceRunner",
+    "MaintenanceReport",
+    "MaintenanceScheduler",
+    "purge_deprecated_memories",
+]

--- a/maintenance/llm.py
+++ b/maintenance/llm.py
@@ -1,0 +1,258 @@
+"""后台整理唯一 LLM 入口。
+
+所有后台整理 Agent 只能经由本模块调用模型，不直接访问 provider。
+硬约束（对齐 Memento LLMClient）：
+  - 仅后台整理模块可调用
+  - 候选对先经向量预筛，再交 LLM 裁决
+  - pair-hash 磁盘缓存，同对同模型永不重判
+  - 三态裁决：link / merge / none / None（不可用/解析失败保持现状）
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from astrbot.api import logger
+
+
+@dataclass
+class LLMVerdict:
+    """LLM 对一对候选的裁决。
+
+    verdict:
+      "link"  —— 两条记忆语义相关，应建边
+      "merge" —— 两条记忆几乎同一件事，应融合（fused_text 给出合成文本）
+      "none"  —— 不相关或重复度不够，什么都不做
+      None    —— LLM 不可用 / 解析失败 / 超时（调用方保守地不做改动）
+    """
+
+    verdict: str | None
+    reason: str = ""
+    weight: float = 0.0  # link 时建议的边权
+    fused_text: str = ""  # merge 时合成的文本
+
+
+class MaintenanceLLM:
+    """后台整理专用 LLM 客户端，带磁盘缓存和调用统计。"""
+
+    def __init__(
+        self,
+        context: Any,
+        cache_dir: str | os.PathLike | None = None,
+        cache_enabled: bool = True,
+        default_model_id: str = "",
+        max_calls_per_cycle: int = 50,
+    ) -> None:
+        self._context = context
+        self._default_model_id = default_model_id
+        self._max_calls_per_cycle = max_calls_per_cycle
+        self._cache_enabled = cache_enabled
+        self._calls = 0
+        self._cache_hits = 0
+        self._errors = 0
+
+        # 缓存目录：默认用 AstrBot 数据目录
+        if cache_dir is None:
+            try:
+                from astrbot.core.utils.astrbot_path import get_astrbot_data_path
+
+                cache_dir = Path(get_astrbot_data_path()) / "plugin_data" / "simple_long_memory" / "llm_cache"
+            except Exception:
+                cache_dir = Path("data") / "llm_cache"
+        self._cache_dir = Path(cache_dir)
+        if cache_enabled:
+            self._cache_dir.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def available(self) -> bool:
+        """LLM 是否可用（有 context 即可，具体模型调用时确定）。"""
+        return self._context is not None
+
+    @property
+    def calls(self) -> int:
+        return self._calls
+
+    @property
+    def cache_hits(self) -> int:
+        return self._cache_hits
+
+    @property
+    def errors(self) -> int:
+        return self._errors
+
+    @property
+    def remaining_calls(self) -> int:
+        return max(0, self._max_calls_per_cycle - self._calls)
+
+    def reset_cycle_stats(self) -> None:
+        """每个整理周期开始时重置统计。"""
+        self._calls = 0
+        self._cache_hits = 0
+        self._errors = 0
+
+    # ─── 缓存 ───────────────────────────────────────────────
+
+    def _cache_key(self, text_a: str, text_b: str, task: str, model_id: str) -> str:
+        """规范化对称文本对 + 模型 + 任务 → sha256。"""
+        a = re.sub(r"\s+", " ", text_a).strip().lower()
+        b = re.sub(r"\s+", " ", text_b).strip().lower()
+        if a > b:
+            a, b = b, a
+        payload = {"model": model_id, "task": task, "a": a, "b": b}
+        raw = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+    def _cache_path(self, key: str) -> Path:
+        return self._cache_dir / f"{key}.json"
+
+    def _cache_get(self, key: str) -> dict[str, Any] | None:
+        if not self._cache_enabled:
+            return None
+        path = self._cache_path(key)
+        if not path.exists():
+            return None
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            path.unlink(missing_ok=True)
+            return None
+
+    def _cache_put(self, key: str, data: dict[str, Any]) -> None:
+        if not self._cache_enabled:
+            return
+        try:
+            self._cache_path(key).write_text(
+                json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
+            )
+        except Exception as e:
+            logger.debug(f"[简单长期记忆] LLM 缓存写入失败: {e}")
+
+    # ─── JSON 解析 ──────────────────────────────────────────
+
+    @staticmethod
+    def _parse_json(raw: str) -> dict[str, Any] | None:
+        """从 LLM 输出提取 JSON。"""
+        candidate = raw.strip()
+        # 尝试提取 ```json ... ``` 块
+        m = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", candidate, re.DOTALL)
+        if m:
+            candidate = m.group(1)
+        else:
+            # 尝试提取第一个 { 到最后一个 }
+            start = candidate.find("{")
+            end = candidate.rfind("}")
+            if 0 <= start < end:
+                candidate = candidate[start : end + 1]
+        try:
+            return json.loads(candidate)
+        except Exception:
+            return None
+
+    # ─── 核心调用 ───────────────────────────────────────────
+
+    async def _chat(
+        self, system_prompt: str, user_prompt: str, model_id: str = ""
+    ) -> str | None:
+        """调用 LLM，返回原始文本。失败返回 None。"""
+        if self._calls >= self._max_calls_per_cycle:
+            logger.warning(
+                f"[简单长期记忆] 本周期 LLM 调用已达上限 {self._max_calls_per_cycle}，跳过"
+            )
+            return None
+
+        provider_id = model_id or self._default_model_id
+        if not provider_id:
+            logger.debug("[简单长期记忆] 未配置整理模型，跳过 LLM 调用")
+            return None
+
+        try:
+            # AstrBot context.llm_generate 接口
+            response = await self._context.llm_generate(
+                chat_provider_id=provider_id,
+                prompt=f"{system_prompt}\n\n{user_prompt}",
+            )
+            self._calls += 1
+            return getattr(response, "completion_text", "") or ""
+        except Exception as e:
+            self._errors += 1
+            logger.warning(f"[简单长期记忆] LLM 调用失败: {e}")
+            return None
+
+    # ─── 任务接口 ───────────────────────────────────────────
+
+    async def judge_relation(
+        self,
+        text_a: str,
+        text_b: str,
+        cosine: float = 0.0,
+        model_id: str = "",
+    ) -> LLMVerdict:
+        """裁决两条记忆是 link / merge / none。
+
+        候选对在调用前已做余弦预筛（由调用方负责），这里 LLM 只看文本。
+        """
+        key = self._cache_key(text_a, text_b, task="judge_relation", model_id=model_id)
+        cached = self._cache_get(key)
+        if cached is not None:
+            self._cache_hits += 1
+            return LLMVerdict(
+                verdict=cached.get("verdict"),
+                reason=cached.get("reason", ""),
+                weight=float(cached.get("weight", 0.0)),
+                fused_text=cached.get("fused_text", ""),
+            )
+
+        system = (
+            "你是记忆库的离线整理员。给你两条记忆，判断它们的关系，只回 JSON。"
+            "字段：verdict（'link'/'merge'/'none'）、reason（<=30字）、"
+            "weight（0~1，link 时建议边权）、fused_text（merge 时合成一条简洁文本）。"
+            "link=语义相关应建边；merge=几乎同一件事应合并；none=都不。"
+        )
+        user = (
+            f"记忆A：\n{text_a}\n\n"
+            f"记忆B：\n{text_b}\n\n"
+            f"（向量余弦 {cosine:.3f}）\n"
+            "只回 JSON。"
+        )
+        raw = await self._chat(system, user, model_id)
+        if raw is None:
+            return LLMVerdict(verdict=None, reason="LLM unavailable")
+
+        parsed = self._parse_json(raw)
+        if parsed is None:
+            return LLMVerdict(verdict=None, reason="parse failed")
+
+        verdict = LLMVerdict(
+            verdict=parsed.get("verdict"),
+            reason=parsed.get("reason", ""),
+            weight=float(parsed.get("weight", 0.0) or 0.0),
+            fused_text=parsed.get("fused_text", ""),
+        )
+        # 规范化 verdict
+        if verdict.verdict not in {"link", "merge", "none"}:
+            verdict.verdict = "none"
+        self._cache_put(
+            key,
+            {
+                "verdict": verdict.verdict,
+                "reason": verdict.reason,
+                "weight": verdict.weight,
+                "fused_text": verdict.fused_text,
+            },
+        )
+        return verdict
+
+    def stats(self) -> dict[str, Any]:
+        """本周期统计。"""
+        return {
+            "calls": self._calls,
+            "cache_hits": self._cache_hits,
+            "errors": self._errors,
+            "remaining": self.remaining_calls,
+        }

--- a/maintenance/runner.py
+++ b/maintenance/runner.py
@@ -1,0 +1,351 @@
+"""后台整理执行管线。
+
+一次整理周期 = 一条顺序管线：
+  purge（纯逻辑）→ organizer → analyst → reviewer（复核前两个角色的 manifest）
+
+所有 Agent 只输出结构化 manifest，Host 解析后才执行 DB 写入。
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from astrbot.api import logger
+
+from .llm import MaintenanceLLM
+from .prompts import build_prompt, DEFAULT_ORGANIZER_PROMPT, DEFAULT_ANALYST_PROMPT, DEFAULT_REVIEWER_PROMPT
+
+
+@dataclass
+class AgentManifest:
+    """Agent 输出的结构化操作清单。"""
+
+    agent_type: str  # organizer / analyst / reviewer
+    operations: list[dict[str, Any]] = field(default_factory=list)
+    notes: str = ""
+    raw_response: str = ""
+    parsed: bool = False
+    error: str = ""
+
+
+@dataclass
+class MaintenanceReport:
+    """一次整理周期的结构化报告。"""
+
+    session_id: str
+    started_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    finished_at: str = ""
+    duration_ms: float = 0.0
+
+    # 各阶段统计
+    purge_result: dict[str, int] = field(default_factory=dict)
+    organizer_manifest: AgentManifest | None = None
+    analyst_manifest: AgentManifest | None = None
+    reviewer_verdicts: list[dict[str, Any]] = field(default_factory=list)
+
+    # LLM 统计
+    llm_stats: dict[str, Any] = field(default_factory=dict)
+
+    # 执行结果
+    executed_ops: int = 0
+    skipped_ops: int = 0
+    failed_ops: int = 0
+    errors: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "duration_ms": self.duration_ms,
+            "purge_result": self.purge_result,
+            "organizer": {
+                "ops_count": len(self.organizer_manifest.operations) if self.organizer_manifest else 0,
+                "parsed": self.organizer_manifest.parsed if self.organizer_manifest else False,
+                "error": self.organizer_manifest.error if self.organizer_manifest else "",
+            },
+            "analyst": {
+                "ops_count": len(self.analyst_manifest.operations) if self.analyst_manifest else 0,
+                "parsed": self.analyst_manifest.parsed if self.analyst_manifest else False,
+                "error": self.analyst_manifest.error if self.analyst_manifest else "",
+            },
+            "reviewer_verdicts_count": len(self.reviewer_verdicts),
+            "llm_stats": self.llm_stats,
+            "executed_ops": self.executed_ops,
+            "skipped_ops": self.skipped_ops,
+            "failed_ops": self.failed_ops,
+            "errors": self.errors,
+        }
+
+
+class MaintenanceRunner:
+    """后台整理执行管线。"""
+
+    def __init__(
+        self,
+        context: Any,
+        memory_mgr: Any,
+        llm: MaintenanceLLM,
+        config: dict[str, Any],
+    ) -> None:
+        self._context = context
+        self._memory_mgr = memory_mgr
+        self._llm = llm
+        self._config = config
+        self._running = False
+
+    async def run_cycle(self) -> MaintenanceReport:
+        """执行一次完整整理周期。"""
+        if self._running:
+            logger.warning("[简单长期记忆] 整理周期已在运行，跳过")
+            raise RuntimeError("maintenance cycle already running")
+
+        self._running = True
+        session_id = f"maint-{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}-{uuid.uuid4().hex[:8]}"
+        report = MaintenanceReport(session_id=session_id)
+        started = datetime.now(timezone.utc)
+
+        try:
+            logger.info(f"[简单长期记忆] 开始整理周期: {session_id}")
+
+            # 重置 LLM 统计
+            self._llm.reset_cycle_stats()
+
+            # ── 阶段 0: purge（纯逻辑，无 LLM）──
+            if self._config.get("auto_purge_enabled", True):
+                purge_days = self._config.get("auto_purge_after_days", 7)
+                try:
+                    purge_result = await self._memory_mgr.purge_deprecated(after_days=purge_days)
+                    report.purge_result = purge_result
+                    logger.info(
+                        f"[简单长期记忆] purge 完成: {purge_result.get('purged', 0)} 条记忆"
+                    )
+                except Exception as e:
+                    report.errors.append(f"purge: {e}")
+                    logger.warning(f"[简单长期记忆] purge 失败: {e}")
+
+            # ── 阶段 1: organizer（整理师）──
+            if self._config.get("maintenance_organizer_enabled", True):
+                try:
+                    report.organizer_manifest = await self._run_organizer()
+                except Exception as e:
+                    report.errors.append(f"organizer: {e}")
+                    logger.warning(f"[简单长期记忆] organizer 失败: {e}")
+
+            # ── 阶段 2: analyst（分析师）──
+            if self._config.get("maintenance_analyst_enabled", True):
+                try:
+                    report.analyst_manifest = await self._run_analyst()
+                except Exception as e:
+                    report.errors.append(f"analyst: {e}")
+                    logger.warning(f"[简单长期记忆] analyst 失败: {e}")
+
+            # ── 阶段 3: reviewer（审核员）──
+            if self._config.get("maintenance_reviewer_enabled", True):
+                try:
+                    report.reviewer_verdicts = await self._run_reviewer(
+                        organizer_manifest=report.organizer_manifest,
+                        analyst_manifest=report.analyst_manifest,
+                    )
+                except Exception as e:
+                    report.errors.append(f"reviewer: {e}")
+                    logger.warning(f"[简单长期记忆] reviewer 失败: {e}")
+
+            # ── 阶段 4: Host 执行（Phase 3/4/5 实现具体操作执行）──
+            # 目前只记录 manifest，不执行实际操作
+            report.executed_ops = 0
+            report.skipped_ops = (
+                len(report.organizer_manifest.operations) if report.organizer_manifest else 0
+            ) + (
+                len(report.analyst_manifest.operations) if report.analyst_manifest else 0
+            )
+
+            # LLM 统计
+            report.llm_stats = self._llm.stats()
+
+        except Exception as e:
+            report.errors.append(f"cycle: {e}")
+            logger.error(f"[简单长期记忆] 整理周期异常: {e}")
+        finally:
+            finished = datetime.now(timezone.utc)
+            report.finished_at = finished.isoformat()
+            report.duration_ms = (finished - started).total_seconds() * 1000
+            self._running = False
+
+            # 落 KV（Phase 2 先日志输出，Phase 3 接 KV）
+            logger.info(
+                f"[简单长期记忆] 整理周期完成: {session_id}, "
+                f"耗时 {report.duration_ms:.0f}ms, "
+                f"LLM 调用 {report.llm_stats.get('calls', 0)} 次"
+            )
+
+        return report
+
+    async def _run_organizer(self) -> AgentManifest:
+        """运行整理师：去重合并、质量精炼。"""
+        manifest = AgentManifest(agent_type="organizer")
+
+        # 拉取记忆列表（简化版，Phase 3 完善）
+        memories_text = await self._get_memories_text()
+        memory_count = await self._get_memory_count()
+
+        # 组装 prompt
+        variables = {
+            "persona_summary": await self._get_persona_summary(),
+            "memories": memories_text,
+            "memory_count": memory_count,
+            "memory_stats": "{}",  # Phase 3 完善
+            "current_time": datetime.now(timezone.utc).isoformat(),
+            "admin_guides": "",  # Phase 5 完善
+        }
+        prompt = build_prompt(
+            default_template=DEFAULT_ORGANIZER_PROMPT,
+            variables=variables,
+            prompt_override=self._config.get("maintenance_organizer_prompt_override", ""),
+            prompt_extra=self._config.get("maintenance_organizer_prompt_extra", ""),
+        )
+
+        # 调用 LLM
+        model_id = self._config.get("maintenance_model_id", "")
+        raw = await self._llm._chat(
+            system_prompt="你是记忆整理师，只输出结构化 JSON。",
+            user_prompt=prompt,
+            model_id=model_id,
+        )
+        manifest.raw_response = raw or ""
+
+        if raw:
+            parsed = self._llm._parse_json(raw)
+            if parsed:
+                manifest.parsed = True
+                manifest.operations = parsed.get("merge", []) + parsed.get("archive", []) + parsed.get("update", [])
+                manifest.notes = parsed.get("notes", "")
+            else:
+                manifest.error = "JSON parse failed"
+
+        return manifest
+
+    async def _run_analyst(self) -> AgentManifest:
+        """运行分析师：关联发现、矛盾检测。"""
+        manifest = AgentManifest(agent_type="analyst")
+
+        # 拉取数据
+        memories_text = await self._get_memories_text()
+        memory_count = await self._get_memory_count()
+        conversation_history = await self._get_conversation_history()
+
+        # 组装 prompt
+        variables = {
+            "persona_summary": await self._get_persona_summary(),
+            "memories": memories_text,
+            "memory_count": memory_count,
+            "memory_stats": "{}",
+            "current_time": datetime.now(timezone.utc).isoformat(),
+            "conversation_history": conversation_history,
+            "admin_guides": "",
+        }
+        prompt = build_prompt(
+            default_template=DEFAULT_ANALYST_PROMPT,
+            variables=variables,
+            prompt_override=self._config.get("maintenance_analyst_prompt_override", ""),
+            prompt_extra=self._config.get("maintenance_analyst_prompt_extra", ""),
+        )
+
+        # 调用 LLM
+        model_id = self._config.get("maintenance_model_id", "")
+        raw = await self._llm._chat(
+            system_prompt="你是记忆分析师，只输出结构化 JSON。",
+            user_prompt=prompt,
+            model_id=model_id,
+        )
+        manifest.raw_response = raw or ""
+
+        if raw:
+            parsed = self._llm._parse_json(raw)
+            if parsed:
+                manifest.parsed = True
+                manifest.operations = parsed.get("new_links", [])
+                manifest.notes = parsed.get("notes", "")
+            else:
+                manifest.error = "JSON parse failed"
+
+        return manifest
+
+    async def _run_reviewer(
+        self,
+        organizer_manifest: AgentManifest | None,
+        analyst_manifest: AgentManifest | None,
+    ) -> list[dict[str, Any]]:
+        """运行审核员：复核操作建议。"""
+        verdicts: list[dict[str, Any]] = []
+
+        # 收集待审核的 manifest
+        proposed_changes = []
+        if organizer_manifest and organizer_manifest.parsed:
+            proposed_changes.extend(organizer_manifest.operations)
+        if analyst_manifest and analyst_manifest.parsed:
+            proposed_changes.extend(analyst_manifest.operations)
+
+        if not proposed_changes:
+            return verdicts
+
+        # 组装 prompt
+        variables = {
+            "proposed_changes": json.dumps(proposed_changes, ensure_ascii=False, indent=2),
+            "original_data": "{}",  # Phase 5 完善
+            "persona_summary": await self._get_persona_summary(),
+            "admin_guides": "",
+        }
+        prompt = build_prompt(
+            default_template=DEFAULT_REVIEWER_PROMPT,
+            variables=variables,
+            prompt_override=self._config.get("maintenance_reviewer_prompt_override", ""),
+            prompt_extra=self._config.get("maintenance_reviewer_prompt_extra", ""),
+        )
+
+        # 调用 LLM
+        model_id = self._config.get("maintenance_reviewer_model_id", "") or self._config.get("maintenance_model_id", "")
+        raw = await self._llm._chat(
+            system_prompt="你是记忆操作审核员，只输出结构化 JSON。",
+            user_prompt=prompt,
+            model_id=model_id,
+        )
+
+        if raw:
+            parsed = self._llm._parse_json(raw)
+            if parsed:
+                verdicts = parsed.get("verdicts", [])
+
+        return verdicts
+
+    # ─── 数据拉取辅助（Phase 3/4 完善）────────────────────
+
+    async def _get_memories_text(self) -> str:
+        """拉取记忆列表文本（简化版）。"""
+        # TODO: Phase 3 从 memory_mgr 拉取实际记忆
+        return "# 记忆池\n（暂无数据）"
+
+    async def _get_memory_count(self) -> int:
+        """当前活跃记忆总数。"""
+        # TODO: Phase 3 从 memory_mgr 统计
+        return 0
+
+    async def _get_conversation_history(self) -> str:
+        """拉取对话历史。"""
+        # TODO: Phase 4 从 conversation_manager 拉取
+        return "# 最近对话\n（暂无数据）"
+
+    async def _get_persona_summary(self) -> str:
+        """获取人格摘要。"""
+        mode = self._config.get("persona_mode", "auto")
+        if mode == "manual":
+            return self._config.get("persona_summary", "")
+        elif mode == "off":
+            return ""
+        else:
+            # auto: 从主人格提取（Phase 5 完善）
+            return ""

--- a/maintenance/scheduler.py
+++ b/maintenance/scheduler.py
@@ -10,11 +10,13 @@ from typing import TYPE_CHECKING, Any
 
 from astrbot.api import logger
 
+from .llm import MaintenanceLLM
+from .runner import MaintenanceRunner
+
 if TYPE_CHECKING:
     from astrbot.core.star.context import Context
 
     from ..memory_manager import MemoryManager
-
 
 class MaintenanceScheduler:
     """后台整理调度器，管理所有定时整理任务。"""
@@ -31,6 +33,19 @@ class MaintenanceScheduler:
         self._job_ids: list[str] = []
         self._running_tasks: set[str] = set()  # single-flight 防并发
 
+        # 初始化 LLM 客户端和执行管线
+        maintenance_model_id = config.get("maintenance_model_id", "")
+        self._llm = MaintenanceLLM(
+            context=context,
+            default_model_id=maintenance_model_id,
+            max_calls_per_cycle=config.get("maintenance_max_llm_calls", 50),
+        )
+        self._runner = MaintenanceRunner(
+            context=context,
+            memory_mgr=memory_mgr,
+            llm=self._llm,
+            config=config,
+        )
     async def start(self) -> None:
         """注册所有定时任务到 cron_manager。"""
         if not self._config.get("maintenance_enabled", False):
@@ -65,8 +80,24 @@ class MaintenanceScheduler:
             except Exception as e:
                 logger.warning(f"[简单长期记忆] 注册自动清理任务失败: {e}")
 
-        # TODO: Phase 3+ 注册整理师/分析师/审核员任务
-
+        # 整理周期（完整管线：purge → organizer → analyst → reviewer）
+        if self._config.get("maintenance_enabled", False):
+            maintenance_cron = self._config.get("maintenance_cron", "0 3 * * *")
+            try:
+                job = await cron_mgr.add_basic_job(
+                    name="memory_maintenance_cycle",
+                    cron_expression=maintenance_cron,
+                    handler=self._run_maintenance_cycle,
+                    description="完整记忆整理周期（purge + 整理师 + 分析师 + 审核员）",
+                    persistent=False,
+                    enabled=True,
+                )
+                self._job_ids.append(job.job_id)
+                logger.info(
+                    f"[简单长期记忆] 整理周期已注册: cron={maintenance_cron}"
+                )
+            except Exception as e:
+                logger.warning(f"[简单长期记忆] 注册整理周期任务失败: {e}")
     async def stop(self) -> None:
         """注销所有定时任务。"""
         cron_mgr = self._context.cron_manager
@@ -111,3 +142,29 @@ class MaintenanceScheduler:
             raise  # 传播到 cron manager，记录为失败而非 completed
         finally:
             self._running_tasks.discard("purge")
+
+    async def _run_maintenance_cycle(self, **kwargs: Any) -> None:
+        """执行完整整理周期（single-flight）。"""
+        if "maintenance_cycle" in self._running_tasks:
+            logger.debug("[简单长期记忆] 整理周期已在运行，跳过")
+            return
+        self._running_tasks.add("maintenance_cycle")
+        try:
+            if not self._memory_mgr.is_kb_connected:
+                logger.debug("[简单长期记忆] KB 未连接，跳过整理周期")
+                return
+
+            report = await self._runner.run_cycle()
+            logger.info(
+                f"[简单长期记忆] 整理周期完成: {report.session_id}, "
+                f"purge={report.purge_result.get('purged', 0)}, "
+                f"LLM 调用={report.llm_stats.get('calls', 0)}, "
+                f"错误={len(report.errors)}"
+            )
+            if report.errors:
+                raise RuntimeError(f"整理周期部分失败: {report.errors}")
+        except Exception as e:
+            logger.warning(f"[简单长期记忆] 整理周期失败: {e}")
+            raise
+        finally:
+            self._running_tasks.discard("maintenance_cycle")


### PR DESCRIPTION
## Phase 2 核心框架

### 新增文件
- **maintenance/llm.py** (258行): 唯一 LLM 入口
  - pair-hash 磁盘缓存（sha256，规范化对称文本对）
  - 三态裁决：link / merge / none / None（不可用保持现状）
  - 每周期调用上限硬约束
  - 调用统计（calls/cache_hits/errors/remaining）

- **maintenance/runner.py** (351行): 执行管线框架
  - MaintenanceReport：结构化周期报告（session_id/各阶段统计/LLM 统计/执行结果）
  - AgentManifest：Agent 输出操作清单
  - 顺序管线：purge → organizer → analyst → reviewer
  - single-flight 防并发

### 修改文件
- **maintenance/scheduler.py**: 接入 runner，注册整理周期 cron job（默认 03:00）
- **_conf_schema.json**: 补 maintenance_cron + maintenance_max_llm_calls

### 设计约束（对齐 Memento SleepEngine）
1. 唯一 LLM 入口：所有 Agent 只能经由 llm.py 调用模型
2. 两级预筛：候选先经算法层预筛，再交 LLM 裁决（Phase 3/4 实现）
3. pair-hash 缓存：同对同模型永不重判
4. 三态裁决：LLM 不可用/解析失败返回 None，调用方保持现状

### 待后续 Phase 实现
- Phase 3: organizer 具体实现（去重合并 + 质量精炼）
- Phase 4: analyst 具体实现（关联发现 + 矛盾检测 + 对话历史拉取）
- Phase 5: reviewer 具体实现（互审模式 + 人工升级）

无 P1 级别问题，请审查合并到 dev

## Summary by Sourcery

为简单的长期记忆模块引入一个结构化的维护执行流水线，包含单一的 LLM 入口点，以及按周期生成的报告。

New Features:
- 添加专用的 `MaintenanceLLM` 客户端，为维护代理提供基于磁盘的 pair-hash 缓存、调用次数限制，以及基础的 JSON 解析工具。
- 添加 `MaintenanceRunner`，用于编排完整的维护周期（purge → organizer → analyst → reviewer），并生成结构化的 `MaintenanceReport` 对象。
- 通过 `maintenance` 包的命名空间导出维护模块的基础组件（scheduler、runner、LLM client、reports、link manager、purge helpers）。

Enhancements:
- 扩展 `MaintenanceScheduler`，用于初始化维护用的 LLM 和 runner，并注册完整的维护 cron 任务以运行周期性流水线。
- 将 LLM 使用统计信息接入维护周期日志，以便更好地观测后台记忆处理情况。

Build:
- 扩展配置 schema，以支持维护 cron 调度和每个周期的最大 LLM 调用次数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a structured maintenance execution pipeline with a single LLM entrypoint and per-cycle reporting for the simple long-term memory module.

New Features:
- Add a dedicated MaintenanceLLM client with disk-based pair-hash caching, call limiting, and basic JSON parsing utilities for maintenance agents.
- Add MaintenanceRunner to orchestrate a full maintenance cycle (purge → organizer → analyst → reviewer) and produce structured MaintenanceReport objects.
- Expose maintenance module primitives (scheduler, runner, LLM client, reports, link manager, purge helpers) via the maintenance package namespace.

Enhancements:
- Extend MaintenanceScheduler to initialize the maintenance LLM and runner, and to register a full maintenance cron job for the periodic pipeline.
- Wire LLM usage stats into maintenance cycle logging for better observability of background memory processing.

Build:
- Extend configuration schema to support maintenance cron scheduling and maximum LLM calls per cycle.

</details>