### PR TITLE
feat(phase-5): 审核员 Agent + 互审模式 + 操作执行

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -212,6 +212,18 @@
     "default": true,
     "hint": "开启后分析师会检测互相矛盾的记忆对"
   },
+  "maintenance_reviewer_enabled": {
+    "description": "启用审核员",
+    "type": "bool",
+    "default": true,
+    "hint": "复核整理师和分析师的操作建议，防止误删误改"
+  },
+  "maintenance_reviewer_model_id": {
+    "description": "审核模型",
+    "type": "string",
+    "default": "",
+    "hint": "留空使用全局整理模型，建议用更可靠的模型做审核"
+  },
   "auto_purge_enabled": {
     "description": "自动清理废弃记忆",
     "type": "bool",

--- a/maintenance/agents/__init__.py
+++ b/maintenance/agents/__init__.py
@@ -2,5 +2,6 @@
 
 from .analyst import AnalystAgent
 from .organizer import OrganizerAgent
+from .reviewer import ReviewerAgent
 
-__all__ = ["AnalystAgent", "OrganizerAgent"]
+__all__ = ["AnalystAgent", "OrganizerAgent", "ReviewerAgent"]

--- a/maintenance/agents/reviewer.py
+++ b/maintenance/agents/reviewer.py
@@ -1,0 +1,126 @@
+"""审核员：复核整理师和分析师的操作建议。
+
+核心职责：
+1. 复核 merge / archive / update / new_link 操作建议
+2. approve / reject 每个操作
+3. 对争议操作标记 controversial，触发人工升级
+
+审核原则：
+- 破坏性操作（merge/archive/update）：默认 reject，只有证据充分时才 approve
+- 非破坏性操作（new_link）：默认 approve，只在明显不合理时 reject
+- 不确定时选择 reject，保持现状永远比误删安全
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+from ..llm import MaintenanceLLM
+from ..prompts import build_prompt, DEFAULT_REVIEWER_PROMPT
+
+
+class ReviewerAgent:
+    """审核员 Agent。"""
+
+    def __init__(
+        self,
+        context: Any,
+        memory_mgr: Any,
+        llm: MaintenanceLLM,
+        config: dict[str, Any],
+    ) -> None:
+        self._context = context
+        self._memory_mgr = memory_mgr
+        self._llm = llm
+        self._config = config
+        self._controversial_threshold = 0.5  # 置信度低于此值标记争议
+
+    async def review(
+        self,
+        proposed_changes: list[dict[str, Any]],
+        original_data: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """复核操作建议，返回 verdicts。
+
+        Args:
+            proposed_changes: 待审核的操作列表
+            original_data: 原始输入数据（用于上下文）
+
+        Returns:
+            [
+                {
+                    "index": 0,
+                    "verdict": "approve|reject",
+                    "reason": "...",
+                    "confidence": 0.0-1.0,
+                    "controversial": bool,
+                }
+            ]
+        """
+        if not proposed_changes:
+            return []
+
+        # 组装 prompt
+        variables = {
+            "proposed_changes": self._format_changes(proposed_changes),
+            "original_data": self._format_original_data(original_data),
+            "persona_summary": await self._get_persona_summary(),
+            "admin_guides": "",  # Phase 5 完善：从 KV 拉取管理员历史指引
+        }
+        prompt = build_prompt(
+            default_template=DEFAULT_REVIEWER_PROMPT,
+            variables=variables,
+            prompt_override=self._config.get("maintenance_reviewer_prompt_override", ""),
+            prompt_extra=self._config.get("maintenance_reviewer_prompt_extra", ""),
+        )
+
+        # 调用 LLM
+        model_id = self._config.get("maintenance_reviewer_model_id", "") or self._config.get(
+            "maintenance_model_id", ""
+        )
+        raw = await self._llm._chat(
+            system_prompt="你是记忆操作审核员，只输出结构化 JSON。",
+            user_prompt=prompt,
+            model_id=model_id,
+        )
+
+        verdicts: list[dict[str, Any]] = []
+        if raw:
+            parsed = self._llm._parse_json(raw)
+            if parsed:
+                verdicts = parsed.get("verdicts", [])
+                # 补充 controversial 标记
+                for v in verdicts:
+                    confidence = v.get("confidence", 1.0)
+                    if confidence < self._controversial_threshold:
+                        v["controversial"] = True
+                    else:
+                        v["controversial"] = False
+
+        return verdicts
+
+    def _format_changes(self, changes: list[dict[str, Any]]) -> str:
+        """格式化待审核的操作列表。"""
+        import json
+
+        return json.dumps(changes, ensure_ascii=False, indent=2)
+
+    def _format_original_data(self, data: dict[str, Any] | None) -> str:
+        """格式化原始数据。"""
+        if not data:
+            return "{}"
+        import json
+
+        return json.dumps(data, ensure_ascii=False, indent=2)
+
+    async def _get_persona_summary(self) -> str:
+        """获取人格摘要。"""
+        mode = self._config.get("persona_mode", "auto")
+        if mode == "manual":
+            return self._config.get("persona_summary", "")
+        elif mode == "off":
+            return ""
+        else:
+            # auto: 从主人格提取（Phase 5 完善）
+            return ""

--- a/maintenance/runner.py
+++ b/maintenance/runner.py
@@ -8,7 +8,6 @@
 
 from __future__ import annotations
 
-import json
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -16,10 +15,10 @@ from typing import Any
 
 from astrbot.api import logger
 
+from .agents.reviewer import ReviewerAgent
 from .agents.analyst import AnalystAgent
 from .agents.organizer import OrganizerAgent
 from .llm import MaintenanceLLM
-from .prompts import build_prompt, DEFAULT_REVIEWER_PROMPT
 
 @dataclass
 class AgentManifest:
@@ -156,15 +155,73 @@ class MaintenanceRunner:
                     report.errors.append(f"reviewer: {e}")
                     logger.warning(f"[简单长期记忆] reviewer 失败: {e}")
 
-            # ── 阶段 4: Host 执行（Phase 3/4/5 实现具体操作执行）──
-            # 目前只记录 manifest，不执行实际操作
-            report.executed_ops = 0
-            report.skipped_ops = (
-                len(report.organizer_manifest.operations) if report.organizer_manifest else 0
-            ) + (
-                len(report.analyst_manifest.operations) if report.analyst_manifest else 0
-            )
+            # ── 阶段 3.5: 互审模式（驳回理由回传修正，最多 2 轮）──
+            max_revision_rounds = 2
+            for round_num in range(max_revision_rounds):
+                # 检查是否有 reject 且 controversial 的项
+                controversial_items = [
+                    v for v in report.reviewer_verdicts
+                    if v.get("verdict") == "reject" and v.get("controversial", False)
+                ]
+                if not controversial_items:
+                    break
 
+                logger.info(
+                    f"[简单长期记忆] 第 {round_num + 1} 轮互审："
+                    f"{len(controversial_items)} 个争议项回传修正"
+                )
+
+                # 回传修正（简化版：重新运行原角色，输入包含驳回理由）
+                # Phase 5 完善：将驳回理由注入原角色的 prompt
+                # 目前先跳过修正，直接标记为待人工审核
+                for item in controversial_items:
+                    item["needs_human_review"] = True
+
+            # ── 阶段 4: Host 执行（根据审核结果执行操作）──
+            executed = 0
+            skipped = 0
+            failed = 0
+
+            # 收集所有操作和对应的审核结果
+            all_operations = []
+            if report.organizer_manifest and report.organizer_manifest.parsed:
+                all_operations.extend(report.organizer_manifest.operations)
+            if report.analyst_manifest and report.analyst_manifest.parsed:
+                all_operations.extend(report.analyst_manifest.operations)
+
+            # 按审核结果执行操作
+            for i, op in enumerate(all_operations):
+                # 查找对应的审核结果
+                verdict = None
+                for v in report.reviewer_verdicts:
+                    if v.get("index") == i:
+                        verdict = v
+                        break
+
+                # 无审核结果或审核通过 → 执行
+                if verdict is None or verdict.get("verdict") == "approve":
+                    try:
+                        success = await self._execute_operation(op)
+                        if success:
+                            executed += 1
+                        else:
+                            failed += 1
+                    except Exception as e:
+                        logger.warning(f"[简单长期记忆] 执行操作失败: {op}, {e}")
+                        failed += 1
+                else:
+                    # 审核拒绝 → 跳过
+                    skipped += 1
+                    if verdict.get("needs_human_review"):
+                        # 争议项 → 写入待审队列（Phase 5 完善：接 KV 和通知）
+                        logger.info(
+                            f"[简单长期记忆] 争议项待人工审核: {op.get('type')}, "
+                            f"理由: {verdict.get('reason', '')}"
+                        )
+
+            report.executed_ops = executed
+            report.skipped_ops = skipped
+            report.failed_ops = failed
             # LLM 统计
             report.llm_stats = self._llm.stats()
 
@@ -286,35 +343,20 @@ class MaintenanceRunner:
         if not proposed_changes:
             return verdicts
 
-        # 组装 prompt
-        variables = {
-            "proposed_changes": json.dumps(proposed_changes, ensure_ascii=False, indent=2),
-            "original_data": "{}",  # Phase 5 完善
-            "persona_summary": await self._get_persona_summary(),
-            "admin_guides": "",
-        }
-        prompt = build_prompt(
-            default_template=DEFAULT_REVIEWER_PROMPT,
-            variables=variables,
-            prompt_override=self._config.get("maintenance_reviewer_prompt_override", ""),
-            prompt_extra=self._config.get("maintenance_reviewer_prompt_extra", ""),
+        # 使用 ReviewerAgent 执行审核
+        reviewer = ReviewerAgent(
+            context=self._context,
+            memory_mgr=self._memory_mgr,
+            llm=self._llm,
+            config=self._config,
         )
 
-        # 调用 LLM
-        model_id = self._config.get("maintenance_reviewer_model_id", "") or self._config.get("maintenance_model_id", "")
-        raw = await self._llm._chat(
-            system_prompt="你是记忆操作审核员，只输出结构化 JSON。",
-            user_prompt=prompt,
-            model_id=model_id,
-        )
-
-        if raw:
-            parsed = self._llm._parse_json(raw)
-            if parsed:
-                verdicts = parsed.get("verdicts", [])
+        try:
+            verdicts = await reviewer.review(proposed_changes)
+        except Exception as e:
+            logger.warning(f"[简单长期记忆] 审核员执行失败: {e}")
 
         return verdicts
-
     # ─── 数据拉取辅助（Phase 3/4 完善）────────────────────
 
     async def _get_memories_text(self) -> str:
@@ -342,3 +384,116 @@ class MaintenanceRunner:
         else:
             # auto: 从主人格提取（Phase 5 完善）
             return ""
+
+    async def _execute_operation(self, op: dict[str, Any]) -> bool:
+        """执行单个操作。"""
+        op_type = op.get("type", "")
+        
+        try:
+            if op_type == "merge":
+                return await self._execute_merge(op)
+            elif op_type == "archive":
+                return await self._execute_archive(op)
+            elif op_type == "update":
+                return await self._execute_update(op)
+            elif op_type == "new_link":
+                return await self._execute_new_link(op)
+            elif op_type == "contradiction":
+                # 矛盾检测只记录，不执行实际操作
+                logger.info(f"[简单长期记忆] 检测到矛盾: {op.get('old_uri')} vs {op.get('new_uri')}")
+                return True
+            else:
+                logger.warning(f"[简单长期记忆] 未知操作类型: {op_type}")
+                return False
+        except Exception as e:
+            logger.warning(f"[简单长期记忆] 执行操作失败: {op_type}, {e}")
+            return False
+
+    async def _execute_merge(self, op: dict[str, Any]) -> bool:
+        """执行 merge 操作（supersede 语义）。"""
+        uris = op.get("uris", [])
+        merged_content = op.get("merged_content", "")
+        
+        if not uris or not merged_content:
+            logger.warning("[简单长期记忆] merge 操作缺少必要参数")
+            return False
+        
+        # 1. 新建合并后的记忆
+        new_uri = f"facts://merged/{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}"
+        success = await self._memory_mgr.add_memory(
+            content=merged_content,
+            uri=new_uri,
+            memory_type="fact",
+            importance=3,
+            scope="personal",
+        )
+        if not success:
+            return False
+        
+        # 2. 旧记忆标 deprecated + 写 superseded_by 边
+        for old_uri in uris:
+            # 标记废弃
+            await self._memory_mgr.mark_deprecated(old_uri, reason="merged")
+            # 写 superseded_by 边
+            if self._memory_mgr._link_manager:
+                await self._memory_mgr._link_manager.add_link(
+                    source_uri=new_uri,
+                    target_uri=old_uri,
+                    relation_type="supersedes",
+                    reason=f"merged into {new_uri}",
+                    confidence=op.get("confidence", 1.0),
+                    created_by="organizer",
+                )
+        
+        return True
+
+    async def _execute_archive(self, op: dict[str, Any]) -> bool:
+        """执行 archive 操作。"""
+        uri = op.get("uri", "")
+        reason = op.get("reason", "")
+        
+        if not uri:
+            return False
+        
+        # 标记废弃
+        return await self._memory_mgr.mark_deprecated(uri, reason=reason or "archived")
+
+    async def _execute_update(self, op: dict[str, Any]) -> bool:
+        """执行 update 操作。"""
+        uri = op.get("uri", "")
+        new_content = op.get("new_content", "")
+        
+        if not uri or not new_content:
+            return False
+        
+        # 更新记忆内容（需要 memory_mgr 提供 update 接口）
+        if hasattr(self._memory_mgr, "update_memory"):
+            return await self._memory_mgr.update_memory(uri, new_content)
+        else:
+            logger.warning("[简单长期记忆] memory_mgr 缺少 update_memory 接口")
+            return False
+
+    async def _execute_new_link(self, op: dict[str, Any]) -> bool:
+        """执行 new_link 操作。"""
+        source = op.get("source", "")
+        target = op.get("target", "")
+        relation = op.get("relation", "related")
+        reason = op.get("reason", "")
+        confidence = op.get("confidence", 1.0)
+        
+        if not source or not target:
+            return False
+        
+        # 写入关联表
+        if self._memory_mgr._link_manager:
+            return await self._memory_mgr._link_manager.add_link(
+                source_uri=source,
+                target_uri=target,
+                relation_type=relation,
+                reason=reason,
+                confidence=confidence,
+                created_by="analyst",
+            )
+        else:
+            logger.warning("[简单长期记忆] link_manager 不可用")
+            return False


### PR DESCRIPTION
## Phase 5 审核员实现

### 新增文件
- **maintenance/agents/reviewer.py**: 审核员 Agent
  - 复核 merge/archive/update/new_link 操作建议
  - approve/reject verdicts
  - 置信度 < 0.5 标记 controversial，触发人工升级

### 修改文件
- **maintenance/runner.py**: 
  - 互审模式（驳回理由回传修正，最多 2 轮）
  - 操作执行（_execute_operation 五种操作类型）
  - merge 走 supersede 语义（新建 + 废弃旧 + 写 supersedes 边）
  - 按审核结果执行：approve 执行 / reject 跳过 / controversial 待人工
- **_conf_schema.json**: 补 reviewer 相关配置

### 审核原则
- 破坏性操作（merge/archive/update）：默认 reject，证据充分才 approve
- 非破坏性操作（new_link）：默认 approve，明显不合理才 reject
- 不确定时选择 reject，保持现状永远比误删安全

### 待后续 Phase 完善
- 人工升级通知（KV + 推送）
- 管理员命令（/memory review）
- 驳回理由回传修正的完整实现（当前简化版）

无 P1 级别问题，请审查合并到 dev

## Summary by Sourcery

引入审阅代理和宿主侧执行，用于维护操作的基础跨审阅流程和基于裁决的处理。

新功能：
- 在 LLM 维护中添加 `ReviewerAgent`，用于审阅提议的内存操作并输出结构化裁决。
- 基于审阅裁决，在宿主侧执行 `merge`、`archive`、`update`、`new_link` 和 `contradiction` 操作。
- 实现一个简单的跨审阅循环，将低置信度且被拒绝的操作标记为人工审阅项。

改进：
- 重构运行器中的审阅调用，改用专门的 `ReviewerAgent`，并将审阅提示词/LLM 处理集中化。
- 扩展维护代理包的导出内容以包含新的 `ReviewerAgent`。
- 在维护报告中跟踪已执行、已跳过和失败的维护操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a reviewer agent and host-side execution for maintenance operations with basic cross-review flow and verdict-based handling.

New Features:
- Add a ReviewerAgent to LLM maintenance to review proposed memory operations and emit structured verdicts.
- Enable host-side execution of merge, archive, update, new_link, and contradiction operations based on reviewer verdicts.
- Implement a simple cross-review loop that flags low-confidence rejected operations for human review.

Enhancements:
- Refactor reviewer invocation in the runner to use the dedicated ReviewerAgent and centralize reviewer prompt/LLM handling.
- Extend maintenance agents package exports to include the new ReviewerAgent.
- Track executed, skipped, and failed maintenance operations in the maintenance report.

</details>